### PR TITLE
Added RDTSCP and CR0 detections

### DIFF
--- a/nohv/cr0.cpp
+++ b/nohv/cr0.cpp
@@ -83,44 +83,43 @@ bool cr0_detected_2() {
 // Some hypervisisors improperly handle reserved bits in cr0
 // Attempting to set any reserved bits in CR0[31:0] is ignored.
 bool cr0_detected_3() {
-    _disable();
-
-    cr0 curr_cr0;
-    curr_cr0.flags = __readcr0();
-
-    __try {
-        auto test_cr0 = curr_cr0;
-
-        // set reserved bits within cr0[31:0]
-        test_cr0.reserved1 = 1;
-        test_cr0.reserved2 = 1;
-        test_cr0.reserved3 = 1;
-
-        // flip CR0.NE so that a vm-exit is triggered
-        test_cr0.numeric_error = !test_cr0.numeric_error;
-
-        // this should not trigger an exception
-        __writecr0(test_cr0.flags);
-
-        // check that the bits were ignored
-        if (__readcr0() == test_cr0.flags) {
-            // restore correct cr0
-            __writecr0(curr_cr0.flags);
-
-            _enable();
-            return true;
-        }
-
-        __writecr0(curr_cr0.flags);
+  _disable();
+  
+  cr0 curr_cr0;
+  curr_cr0.flags = __readcr0();
+  
+  __try {
+    auto test_cr0 = curr_cr0;
+    
+    // set reserved bits within cr0[31:0]
+    test_cr0.reserved1 = 1;
+    test_cr0.reserved2 = 1;
+    test_cr0.reserved3 = 1;
+    
+    // flip CR0.NE so that a vm-exit is triggered
+    test_cr0.numeric_error = !test_cr0.numeric_error;
+    
+    // this should not trigger an exception
+    __writecr0(test_cr0.flags);
+    
+    // check that the bits were ignored
+    if (__readcr0() == test_cr0.flags) {
+      // restore correct cr0
+      __writecr0(curr_cr0.flags);
+      
+      _enable();
+      return true;
     }
-    __except (1) {
-        // restore correct cr0
-        __writecr0(curr_cr0.flags);
-
-        _enable();
-        return true;
-    }
-
+    
+    __writecr0(curr_cr0.flags);
+  } __except (1) {
+    // restore correct cr0
+    __writecr0(curr_cr0.flags);
+            
     _enable();
-    return false;
+    return true;
+  }
+
+  _enable();
+  return false;
 }

--- a/nohv/cr0.cpp
+++ b/nohv/cr0.cpp
@@ -80,3 +80,47 @@ bool cr0_detected_2() {
   return false;
 }
 
+// Some hypervisisors improperly handle reserved bits in cr0
+// Attempting to set any reserved bits in CR0[31:0] is ignored.
+bool cr0_detected_3() {
+    _disable();
+
+    cr0 curr_cr0;
+    curr_cr0.flags = __readcr0();
+
+    __try {
+        auto test_cr0 = curr_cr0;
+
+        // set reserved bits within cr0[31:0]
+        test_cr0.reserved1 = 1;
+        test_cr0.reserved2 = 1;
+        test_cr0.reserved3 = 1;
+
+        // flip CR0.NE so that a vm-exit is triggered
+        test_cr0.numeric_error = !test_cr0.numeric_error;
+
+        // this should not trigger an exception
+        __writecr0(test_cr0.flags);
+
+        // check that the bits were ignored
+        if (__readcr0() == test_cr0.flags) {
+            // restore correct cr0
+            __writecr0(curr_cr0.flags);
+
+            _enable();
+            return true;
+        }
+
+        __writecr0(curr_cr0.flags);
+    }
+    __except (1) {
+        // restore correct cr0
+        __writecr0(curr_cr0.flags);
+
+        _enable();
+        return true;
+    }
+
+    _enable();
+    return false;
+}

--- a/nohv/detections.h
+++ b/nohv/detections.h
@@ -10,6 +10,7 @@ bool msr_detected_2();
 // cr0.cpp
 bool cr0_detected_1();
 bool cr0_detected_2();
+bool cr0_detected_3();
 
 // cr3.cpp
 bool cr3_detected_1();
@@ -36,6 +37,7 @@ bool timing_detected_3();
 bool timing_detected_4();
 bool timing_detected_5();
 bool timing_detected_6();
+bool timing_detected_7();
 
 // debug.cpp
 bool debug_detected_1();

--- a/nohv/main.cpp
+++ b/nohv/main.cpp
@@ -33,6 +33,7 @@ NTSTATUS driver_entry(PDRIVER_OBJECT driver, PUNICODE_STRING) {
   DbgPrint("Testing cr0:\n");
   EXEC_DETECTION(cr0_detected_1);
   EXEC_DETECTION(cr0_detected_2);
+  EXEC_DETECTION(cr0_detected_3);
 
   // cr3.cpp
   DbgPrint("Testing cr3:\n");
@@ -63,6 +64,7 @@ NTSTATUS driver_entry(PDRIVER_OBJECT driver, PUNICODE_STRING) {
   EXEC_DETECTION(timing_detected_4);
   EXEC_DETECTION(timing_detected_5);
   EXEC_DETECTION(timing_detected_6);
+  EXEC_DETECTION(timing_detected_7);
 
   // debug.cpp
   DbgPrint("Testing debug:\n");

--- a/nohv/nohv.vcxproj.filters
+++ b/nohv/nohv.vcxproj.filters
@@ -62,5 +62,8 @@
     <MASM Include="vmx-asm.asm">
       <Filter>Source Files</Filter>
     </MASM>
+    <MASM Include="timing-asm.asm">
+      <Filter>Source Files</Filter>
+    </MASM>
   </ItemGroup>
 </Project>

--- a/nohv/timing-asm.asm
+++ b/nohv/timing-asm.asm
@@ -1,0 +1,31 @@
+.code
+
+check_rdtscp_regs proc
+	mov rax, 0FFFFFFFFFFFFFFFFh
+	mov rdx, 0FFFFFFFFFFFFFFFFh
+	mov rcx, 0FFFFFFFFFFFFFFFFh
+
+	rdtscp
+	
+	shr rax, 32
+	test eax, eax
+	jne detected
+
+	shr rdx, 32
+	test edx, edx
+	jne detected
+
+	shr rcx, 32
+	test ecx, ecx
+	jne detected
+
+	; al is already 0
+	ret
+
+detected:
+	mov al, 1
+	ret
+
+check_rdtscp_regs endp
+
+end

--- a/nohv/timing-asm.asm
+++ b/nohv/timing-asm.asm
@@ -1,30 +1,30 @@
 .code
 
 check_rdtscp_regs proc
-	mov rax, 0FFFFFFFFFFFFFFFFh
-	mov rdx, 0FFFFFFFFFFFFFFFFh
-	mov rcx, 0FFFFFFFFFFFFFFFFh
-
-	rdtscp
-	
-	shr rax, 32
-	test eax, eax
-	jne detected
-
-	shr rdx, 32
-	test edx, edx
-	jne detected
-
-	shr rcx, 32
-	test ecx, ecx
-	jne detected
-
-	; al is already 0
-	ret
+  mov rax, 0FFFFFFFFFFFFFFFFh
+  mov rdx, 0FFFFFFFFFFFFFFFFh
+  mov rcx, 0FFFFFFFFFFFFFFFFh
+  
+  rdtscp
+  
+  shr rax, 32
+  test eax, eax
+  jne detected
+  
+  shr rdx, 32
+  test edx, edx
+  jne detected
+  
+  shr rcx, 32
+  test ecx, ecx
+  jne detected
+  
+  ; al is already 0
+  ret
 
 detected:
-	mov al, 1
-	ret
+  mov al, 1
+  ret
 
 check_rdtscp_regs endp
 

--- a/nohv/timing.cpp
+++ b/nohv/timing.cpp
@@ -334,3 +334,10 @@ bool timing_detected_6() {
   return (uc_timing < wb_timing * 40);
 }
 
+extern "C" bool check_rdtscp_regs();
+
+// This detection occurs due to an improper implementation of rdtscp
+// On processors that support the Intel 64 architecture, the high - order 32 bits of each of RAX, RDX, and RCX are cleared.
+bool timing_detected_7() {
+    return check_rdtscp_regs();
+}

--- a/nohv/timing.cpp
+++ b/nohv/timing.cpp
@@ -339,5 +339,5 @@ extern "C" bool check_rdtscp_regs();
 // This detection occurs due to an improper implementation of rdtscp
 // On processors that support the Intel 64 architecture, the high - order 32 bits of each of RAX, RDX, and RCX are cleared.
 bool timing_detected_7() {
-    return check_rdtscp_regs();
+  return check_rdtscp_regs();
 }


### PR DESCRIPTION
1. RDTSCP detection
According to the manual: "On processors that support the Intel 64 architecture, the high - order 32 bits of each of RAX, RDX, and RCX are cleared." after this instruction is executed.

This could potentially be an issue for hypervisors which do not properly handle this and only write the lower 32 bits when handling RDTSCP

2. CR0 detection
According to the manual: "Attempting to set any reserved bits in CR0[31:0] is ignored."

Some VMMs might end up treating the reserved bits like the CR0[63:32] reserve where #GP(0) is injected.

To be fair, the RDTSCP check might be completely worthless but it might be something to consider.